### PR TITLE
import purify.bitrot

### DIFF
--- a/example/source/app.d
+++ b/example/source/app.d
@@ -1,5 +1,6 @@
 import maxmind.db;
 import std.stdio;
+import std.conv;
 
 /**
  * Program entry point: takes an IP address as the input, and returns a

--- a/source/maxmind/db.d
+++ b/source/maxmind/db.d
@@ -6,6 +6,7 @@ import std.conv : to;
 import std.mmfile;
 import std.regex;
 import std.string;
+import std.bitmanip;
 
 /** Constant byte sequence that marks the beginning of the global metadata section */
 protected const ubyte[] METADATA_MARKER = [0xAB, 0xCD, 0xEF, 'M', 'a', 'x', 'M', 'i', 'n', 'd', '.', 'c', 'o', 'm'];


### PR DESCRIPTION
For at least a year neither the module nor the accompanying example would build due to these required imports.

With the imports, the module works (and more efficiently than my Nim rewrite which closely followed your design, apart from copying a lot more) and the example works with a GeoLite2-Country database.